### PR TITLE
Add AHBS composite index (asset_code, asset_issuer, created_at)

### DIFF
--- a/aquarius_bribes/rewards/migrations/0013_ahbs_asset_date_idx.py
+++ b/aquarius_bribes/rewards/migrations/0013_ahbs_asset_date_idx.py
@@ -1,0 +1,47 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """
+    Composite index on AssetHolderBalanceSnapshot(asset_code, asset_issuer,
+    created_at) — used by get_payable_votes() and therefore by task_pay_rewards,
+    reconcile_bribe_payouts, and check_payout_completeness.
+
+    Before this index the planner used the single-column created_at index and
+    filtered asset_code/asset_issuer via seq scan over the day's rows.
+
+    CREATE INDEX CONCURRENTLY to avoid locking the table on prod; atomic=False
+    is required because CONCURRENTLY cannot run inside a transaction.
+    """
+    atomic = False
+
+    dependencies = [
+        ('rewards', '0012_claimablebalance_claimant'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql=(
+                        'CREATE INDEX CONCURRENTLY IF NOT EXISTS '
+                        '"ahbs_asset_date_idx" '
+                        'ON "rewards_assetholderbalancesnapshot" '
+                        '("asset_code", "asset_issuer", "created_at");'
+                    ),
+                    reverse_sql=(
+                        'DROP INDEX CONCURRENTLY IF EXISTS "ahbs_asset_date_idx";'
+                    ),
+                ),
+            ],
+            state_operations=[
+                migrations.AddIndex(
+                    model_name='assetholderbalancesnapshot',
+                    index=models.Index(
+                        fields=['asset_code', 'asset_issuer', 'created_at'],
+                        name='ahbs_asset_date_idx',
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/aquarius_bribes/rewards/models.py
+++ b/aquarius_bribes/rewards/models.py
@@ -186,6 +186,14 @@ class AssetHolderBalanceSnapshot(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True, db_index=True)
 
+    class Meta:
+        indexes = [
+            models.Index(
+                fields=['asset_code', 'asset_issuer', 'created_at'],
+                name='ahbs_asset_date_idx',
+            ),
+        ]
+
     def __str__(self):
         return '{0}..{1} at {2}: {3} {4}'.format(
             self.account[:8], self.account[-8:], self.created_at.date(), self.balance, self.asset.code,


### PR DESCRIPTION
## Summary

Adds a composite btree index on `AssetHolderBalanceSnapshot(asset_code, asset_issuer, created_at)` to make the trustline lookup in `get_payable_votes` efficient at prod scale.

**Why now:** PR #3 refactors `get_payable_votes` to materialize AHBS account sets in Python and apply them to `VoteSnapshot` as a PG array predicate. That fetch pattern hits AHBS filtered by `(asset_code, asset_issuer, created_at >= day_start, created_at < day_end)` — exactly the columns this index covers. Without it, for AQUA (~140k holders) the query is a seq scan on AHBS.

## Deploy prerequisite

Migration `0013_ahbs_asset_date_idx.py` creates the index with `CONCURRENTLY` / `SeparateDatabaseAndState` (standard approach for large tables), but still requires a maintenance window:

- **Stop `celery-beat`** before applying (prevents `task_pay_rewards` / `task_make_trustees_snapshot` from running during the build).
- **Window:** ~45 min on prod (AHBS is large).
- **Rollback:** `DROP INDEX CONCURRENTLY ahbs_asset_date_idx;` safe to run at any time.

## Test plan

- [x] Migration applies cleanly on local Docker test DB.
- [x] Migration applies cleanly on AWS RDS prevalidation replica (validated during PR #3 prevalidation).
- [ ] Apply in prod window before merging PR #3.